### PR TITLE
str_view(), repetition at most n times yields error #807

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -360,7 +360,6 @@ You can also specify the number of matches precisely:
 
 * `{n}`: exactly n
 * `{n,}`: n or more
-* `{,m}`: at most m
 * `{n,m}`: between n and m
 
 ```{r}


### PR DESCRIPTION
Proposed fix related to this issue: https://github.com/hadley/r4ds/issues/807

A more comprehensive fix should perhaps discuss why "`{,m}`: at most m" does not work (or warn the reader that it does not)